### PR TITLE
Initializing empty variables describing data in .agf files, fixing a bug ✅

### DIFF
--- a/KrakenOS/SystemTools.py
+++ b/KrakenOS/SystemTools.py
@@ -77,6 +77,12 @@ def load_Catalog(FileCat):
     names = np.asarray(names)
     for i in range(0, (len(coords) - 1)):
         ITT = []
+        NM = []
+        ED = []
+        CD = []
+        TD = []
+        OD = []
+        LD = []
         for j in range(coords[i], coords[(i + 1)]):
             cadena = cat[j].split()
             cad = cat[j][2:].split()


### PR DESCRIPTION
This is a minor change in the code to provide a fix in the `load_Catalog(FileCat)` function in the `SystemTools.py` file.

**The issue**

```
for j in range(coords[i], coords[(i + 1)]):
            cadena = cat[j].split()
            cad = cat[j][2:].split()
            if (cadena[0] == 'NM'):
                NM = cad
            if (cadena[0] == 'ED'):
                ED = cad
                if ED[1]=="-":
                    ED[1]="0.0"
            if (cadena[0] == 'CD'):
                CD = cad
            if (cadena[0] == 'TD'):
                TD = cad
            if (cadena[0] == 'OD'):
                OD = cad
            if (cadena[0] == 'LD'):
                LD = cad
            if (cadena[0] == 'IT'):
                IT = cad
                if len(IT)==3:
                    ITT.append(IT)


NM = np.asarray(NM[1:(- 1)], dtype=np.float64)
ED = np.asarray(ED, dtype=np.float64)
CD = np.asarray(CD, dtype=np.float64)
```

When parsing the data from the catalog, if the data doesn't have the ED attribute in it, then the line `ED = np.asarray(ED, dtype=np.float64)` returns an error. 

A simple fix was to initialize the NM, ED, CD, TD, OD, LD, IT variables to empty lists.
