### PR TITLE
fix: load glass catalogs in deterministic order

### DIFF
--- a/KrakenOS/SetupClass.py
+++ b/KrakenOS/SetupClass.py
@@ -60,7 +60,7 @@ class Setup():
         # cat1 = (rute + 'SCHOTT.AGF')
         # cat2 = (rute + 'infrared.agf')
 
-        self.GlassCat =[rute + cat for cat in os.listdir(rute) if cat.endswith(('.AGF', '.agf'))]
+        self.GlassCat = sorted([rute + cat for cat in os.listdir(rute) if cat.endswith(('.AGF', '.agf'))])
         # self.GlassCat.append(cat1)
         # self.GlassCat.append(cat2)
 


### PR DESCRIPTION
`os.listdir` returns the files in a directory in arbitrary order, meaning this can differ from machine to machine. KrakenOS will use the first glass with the specified name it finds. For multiple definitions of the same glass name this means the order the catalogs are loaded is very important. Sorting the catalog names will load them in the same order every time.

For example, there are multiple definitions of the `LAF2` material, for which the nikon catalog defines less coefficients than the formula expects. Depending on the machine, the nikon catalog would get loaded before other catalog, causing the invalid coefficients to be used. (See [nikon.agf](https://github.com/Garchupiter/Kraken-Optical-Simulator/blob/main/KrakenOS/Cat/nikon.agf#L13417) and [Physics.py](https://github.com/Garchupiter/Kraken-Optical-Simulator/blob/main/KrakenOS/Physics.py#L243))
