### PR TITLE
Fix Python 3.13 compatibility and example runtime issues

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+export DIRENV_WARN_TIMEOUT=20s
+
+eval "$(devenv direnvrc)"
+
+use devenv
+
+if [[ -d .devenv/state/venv/bin ]]; then
+  PATH_add .devenv/state/venv/bin
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.devenv/
 env/
 venv/
 ENV/

--- a/KrakenOS/Display.py
+++ b/KrakenOS/Display.py
@@ -1,3 +1,14 @@
+import os
+import tempfile
+
+import matplotlib
+if os.environ.get("WAYLAND_DISPLAY") or os.environ.get("DISPLAY"):
+    for candidate in ("qtagg", "tkagg", "gtk3agg", "gtk4agg"):
+        try:
+            matplotlib.use(candidate, force=True)
+            break
+        except Exception:
+            continue
 
 import numpy as np
 import pyvista as pv
@@ -198,12 +209,12 @@ def display3d_old(SYSTEM, RAYS, view=0, inline=False,     BackgCol= 'white', Bac
                 if (recorte == 2):
                     clippedx = AAAA.clip((1, 0, 0), invert=False)
                     c = c.merge(clippedx)
-                p.add_mesh(c, color, opacity=OPA, specular=1, specular_power=15, smooth_shading=True, show_edges=False)
+                p.add_mesh(c, color=color, opacity=OPA, specular=1, specular_power=15, smooth_shading=True, show_edges=False)
                 edges = c.extract_feature_edges(feature_angle=10, boundary_edges=True, feature_edges=False, manifold_edges=False)
                 if SYSTEM.SDT_0[n].Solid_3d_stl != "None" and recorte ==0:
                     print(" ") # No edges
                 else:
-                    p.add_mesh(edges, 'red')
+                    p.add_mesh(edges, color='red')
                 points2 = np.c_[0.0, 0.0, 0.0]
                 c = pv.PolyData(points2)
     p.add_mesh(SYSTEM.DDD, color=[0.5, 0.5, 0.5], opacity=OPA, show_edges=None)
@@ -223,16 +234,16 @@ def display3d_old(SYSTEM, RAYS, view=0, inline=False,     BackgCol= 'white', Bac
                 color = SYSTEM.SDT_0[g].Color
             if (recorte == 1):
                 clippedx = SYSTEM.BBB[n].clip('x', invert=False)
-                p.add_mesh(clippedx, color ,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedx, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
                 clippedy = SYSTEM.BBB[n].clip('-y', invert=False)
-                p.add_mesh(clippedy, color,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedy, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
             if (recorte == 0):
                 No_clipped = SYSTEM.BBB[n]
-                p.add_mesh(No_clipped, color,opacity=OPA, smooth_shading=False, show_edges=None)
+                p.add_mesh(No_clipped, color=color, opacity=OPA, smooth_shading=False, show_edges=None)
             if (recorte == 2):
                 BBBB = SYSTEM.BBB[n]
                 clippedx = BBBB.clip((1, 0, 0), invert=False)
-                p.add_mesh(clippedx, color,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedx, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
         n = (n + 1)
 
     if INST == True:
@@ -437,6 +448,11 @@ def display3d_colab(
         _HAS_IPY = True
     except Exception:
         _HAS_IPY = False
+
+    if filename.startswith("/content/") and not os.path.isdir("/content"):
+        filename = os.path.join(tempfile.gettempdir(), os.path.basename(filename))
+
+    os.makedirs(os.path.dirname(filename) or ".", exist_ok=True)
 
     # 1) Asegura Xvfb (headless render) en Colab
     # Si no estás en colab igual funciona en modo off_screen si hay soporte
@@ -672,14 +688,14 @@ def plot3d(SYSTEM, view, p, OPA):
                     clippedx = AAAA.clip((1, 0, 0), invert=False)
                     c = c.merge(clippedx)
 
-                p.add_mesh(c, color, opacity=OPA, specular=1, specular_power=15, smooth_shading=True, show_edges=False)
+                p.add_mesh(c, color=color, opacity=OPA, specular=1, specular_power=15, smooth_shading=True, show_edges=False)
                 edges = c.extract_feature_edges(feature_angle=10, boundary_edges=True, feature_edges=False, manifold_edges=False)
 
                # TTT.append(c)
                 if SYSTEM.SDT_0[n].Solid_3d_stl != "None" and recorte ==0:
                     print(" ") # No edges
                 else:
-                    p.add_mesh(edges, 'red')
+                    p.add_mesh(edges, color='red')
                 points2 = np.c_[0.0, 0.0, 0.0]
                 c = pv.PolyData(points2)
     p.add_mesh(SYSTEM.DDD, color=[0.5, 0.5, 0.5], opacity=OPA, show_edges=None)
@@ -700,19 +716,19 @@ def plot3d(SYSTEM, view, p, OPA):
                 color = SYSTEM.SDT_0[g].Color
             if (recorte == 1):
                 clippedx = SYSTEM.BBB[n].clip('x', invert=False)
-                p.add_mesh(clippedx, color ,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedx, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
                 clippedy = SYSTEM.BBB[n].clip('-y', invert=False)
-                p.add_mesh(clippedy, color,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedy, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
 
 
             if (recorte == 0):
                 No_clipped = SYSTEM.BBB[n]
-                p.add_mesh(No_clipped, color,opacity=OPA, smooth_shading=False, show_edges=None)
+                p.add_mesh(No_clipped, color=color, opacity=OPA, smooth_shading=False, show_edges=None)
 
             if (recorte == 2):
                 BBBB = SYSTEM.BBB[n]
                 clippedx = BBBB.clip((1, 0, 0), invert=False)
-                p.add_mesh(clippedx, color,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedx, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
 
         n = (n + 1)
 
@@ -1003,6 +1019,17 @@ def display2d(SYSTEM, RAYS, view=0, arrow=0, nrays = 0, figsize: Tuple=(10, 4), 
 
 ###############################################################################
 
+def _scalar_coord(value, index=0):
+    arr = np.asarray(value)
+    if arr.ndim == 0:
+        return float(arr)
+    flat = arr.reshape(-1)
+    if flat.size == 0:
+        return 0.0
+    idx = max(min(index, flat.size - 1), -flat.size)
+    return float(flat[idx])
+
+
 def Plot2DSurf(SYSTEM, view, ax1):
     fs = 11
     NN = SYSTEM.AAA.n_blocks
@@ -1026,6 +1053,8 @@ def Plot2DSurf(SYSTEM, view, ax1):
             AAAA = SYSTEM.AAA[n]
             if (SYSTEM.SDT_0[n].Glass != 'NULL'):
                 (PosX, PosY) = SYSTEM.SDT_0[n].Nm_Pos
+                PosX = _scalar_coord(PosX)
+                PosY = _scalar_coord(PosY)
                 s = SYSTEM.SDT_0[n].Name
                 ss = SYSTEM.Object_Num[n]
                 if (view == 0):
@@ -1036,21 +1065,57 @@ def Plot2DSurf(SYSTEM, view, ax1):
                     (ax, ay, az) = edge_3d(AAAA, (- 1), 0, 0, solid)
                     (az, ay) = filter_face_2dplot(az, ay, solid)
                     ax1.plot(az, ay, LT, c='black', linewidth=0.5)
-                    ax1.text(((np.max(az) + PosX) + 1), ((np.max(ay) + PosY) - 1), s, fontsize=fs)
+                    ax1.text(
+                        _scalar_coord((np.max(az) + PosX) + 1),
+                        _scalar_coord((np.max(ay) + PosY) - 1),
+                        s,
+                        fontsize=fs,
+                    )
                     delta = ((np.max(ay) - np.min(ay)) / 10)
 
 
                     ABC=int(0.5*(np.argmin(ay) - np.argmax(ay)))
-                    CordABC = az[ABC]
+                    CordABC = _scalar_coord(az, ABC)
 
 
                     if SYSTEM.SDT_0[n].NumLabel == 1:
 
-                        ax1.text(CordABC, sn*1.5*(np.min(ay) - (1.5 * delta)), (('[' + str(ss)) + ']'), fontsize=fs)
-                        ax1.plot([CordABC, CordABC], [np.mean(ay), sn*1.5*(np.min(ay) - delta)], '-.', c='red', linewidth=0.5)
+                        ax1.text(
+                            _scalar_coord(CordABC),
+                            _scalar_coord(sn * 1.5 * (np.min(ay) - (1.5 * delta))),
+                            (('[' + str(ss)) + ']'),
+                            fontsize=fs,
+                        )
+                        ax1.plot(
+                            [_scalar_coord(CordABC), _scalar_coord(CordABC)],
+                            [_scalar_coord(np.mean(ay)), _scalar_coord(sn * 1.5 * (np.min(ay) - delta))],
+                            '-.',
+                            c='red',
+                            linewidth=0.5,
+                        )
                     if ((PosX != 0) or (PosY != 0)):
-                        ax1.arrow((np.max(az) + PosX), (np.max(ay) + PosY/2), (- PosX), (- PosY/2.0), head_width=0.5, head_length=1.0, fc='k', ec='k', length_includes_head=True)
-                        ax1.arrow((np.max(az) + PosX), (np.max(ay) + PosY), (- PosX)*0, (- PosY)/2.0, head_width=0.1, head_length=0.0, fc='k', ec='k', length_includes_head=True)
+                        ax1.arrow(
+                            _scalar_coord(np.max(az) + PosX),
+                            _scalar_coord(np.max(ay) + PosY / 2),
+                            _scalar_coord(-PosX),
+                            _scalar_coord(-PosY / 2.0),
+                            head_width=0.5,
+                            head_length=1.0,
+                            fc='k',
+                            ec='k',
+                            length_includes_head=True,
+                        )
+                        ax1.arrow(
+                            _scalar_coord(np.max(az) + PosX),
+                            _scalar_coord(np.max(ay) + PosY),
+                            _scalar_coord((-PosX) * 0),
+                            _scalar_coord((-PosY) / 2.0),
+                            head_width=0.1,
+                            head_length=0.0,
+                            fc='k',
+                            ec='k',
+                            length_includes_head=True,
+                        )
 
                 if (view == 1):
 
@@ -1061,20 +1126,56 @@ def Plot2DSurf(SYSTEM, view, ax1):
                     (ax, ay, az) = edge_3d(AAAA, 0, (- 1), 0, solid)
                     (az, ax) = filter_face_2dplot(az, ax, solid)
                     ax1.plot(az, ax, LT, c='black', linewidth=0.5)
-                    ax1.text(((np.max(az) + PosX) + 1), ((np.max(ax) + PosY) - 1), s, fontsize=fs)
+                    ax1.text(
+                        _scalar_coord((np.max(az) + PosX) + 1),
+                        _scalar_coord((np.max(ax) + PosY) - 1),
+                        s,
+                        fontsize=fs,
+                    )
                     delta = ((np.max(ax) - np.min(ax)) / 10)
 
                     ABC=int(0.5*(np.argmin(ax) - np.argmax(ax)))
-                    CordABC = az[ABC]
+                    CordABC = _scalar_coord(az, ABC)
 
 
                     if SYSTEM.SDT_0[n].NumLabel == 1:
-                        ax1.text(CordABC, sn*1.5*(np.min(ax) - (1.5 * delta)), (('[' + str(ss)) + ']'), fontsize=fs)
-                        ax1.plot([CordABC, CordABC], [np.mean(ax), sn*1.5*(np.min(ax) - delta)], '-.', c='red', linewidth=0.5)
+                        ax1.text(
+                            _scalar_coord(CordABC),
+                            _scalar_coord(sn * 1.5 * (np.min(ax) - (1.5 * delta))),
+                            (('[' + str(ss)) + ']'),
+                            fontsize=fs,
+                        )
+                        ax1.plot(
+                            [_scalar_coord(CordABC), _scalar_coord(CordABC)],
+                            [_scalar_coord(np.mean(ax)), _scalar_coord(sn * 1.5 * (np.min(ax) - delta))],
+                            '-.',
+                            c='red',
+                            linewidth=0.5,
+                        )
 
                     if ((PosX != 0) or (PosY != 0)):
-                        ax1.arrow((np.max(az) + PosX), (np.max(ax) + PosY/2), (- PosX), (- PosY/2.0), head_width=0.5, head_length=1.0, fc='k', ec='k', length_includes_head=True)
-                        ax1.arrow((np.max(az) + PosX), (np.max(ax) + PosY), (- PosX)*0, (- PosY)/2.0, head_width=0.1, head_length=0.0, fc='k', ec='k', length_includes_head=True)
+                        ax1.arrow(
+                            _scalar_coord(np.max(az) + PosX),
+                            _scalar_coord(np.max(ax) + PosY / 2),
+                            _scalar_coord(-PosX),
+                            _scalar_coord(-PosY / 2.0),
+                            head_width=0.5,
+                            head_length=1.0,
+                            fc='k',
+                            ec='k',
+                            length_includes_head=True,
+                        )
+                        ax1.arrow(
+                            _scalar_coord(np.max(az) + PosX),
+                            _scalar_coord(np.max(ax) + PosY),
+                            _scalar_coord((-PosX) * 0),
+                            _scalar_coord((-PosY) / 2.0),
+                            head_width=0.1,
+                            head_length=0.0,
+                            fc='k',
+                            ec='k',
+                            length_includes_head=True,
+                        )
 
             mx.append(np.max(az))
             mn.append(np.min(az))
@@ -1337,12 +1438,12 @@ def display3d_4OB(SYSTEM, RAYS, view, inline, BackgCol, BackgColTop, GridCol, p)
                 if (recorte == 2):
                     clippedx = AAAA.clip((1, 0, 0), invert=False)
                     c = c.merge(clippedx)
-                p.add_mesh(c, color, opacity=OPA, specular=1, specular_power=15, smooth_shading=True, show_edges=False)
+                p.add_mesh(c, color=color, opacity=OPA, specular=1, specular_power=15, smooth_shading=True, show_edges=False)
                 edges = c.extract_feature_edges(feature_angle=10, boundary_edges=True, feature_edges=False, manifold_edges=False)
                 if SYSTEM.SDT_0[n].Solid_3d_stl != "None" and recorte ==0:
                     print(" ") # No edges
                 else:
-                    p.add_mesh(edges, 'red')
+                    p.add_mesh(edges, color='red')
                 points2 = np.c_[0.0, 0.0, 0.0]
                 c = pv.PolyData(points2)
     p.add_mesh(SYSTEM.DDD, color=[0.5, 0.5, 0.5], opacity=OPA, show_edges=None)
@@ -1362,16 +1463,16 @@ def display3d_4OB(SYSTEM, RAYS, view, inline, BackgCol, BackgColTop, GridCol, p)
                 color = SYSTEM.SDT_0[g].Color
             if (recorte == 1):
                 clippedx = SYSTEM.BBB[n].clip('x', invert=False)
-                p.add_mesh(clippedx, color ,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedx, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
                 clippedy = SYSTEM.BBB[n].clip('-y', invert=False)
-                p.add_mesh(clippedy, color,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedy, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
             if (recorte == 0):
                 No_clipped = SYSTEM.BBB[n]
-                p.add_mesh(No_clipped, color,opacity=OPA, smooth_shading=False, show_edges=None)
+                p.add_mesh(No_clipped, color=color, opacity=OPA, smooth_shading=False, show_edges=None)
             if (recorte == 2):
                 BBBB = SYSTEM.BBB[n]
                 clippedx = BBBB.clip((1, 0, 0), invert=False)
-                p.add_mesh(clippedx, color,opacity=OPA, smooth_shading=True, show_edges=None)
+                p.add_mesh(clippedx, color=color, opacity=OPA, smooth_shading=True, show_edges=None)
         n = (n + 1)
 
     if INST == True:
@@ -1400,5 +1501,5 @@ def display3d_4OB(SYSTEM, RAYS, view, inline, BackgCol, BackgColTop, GridCol, p)
     p.set_background(BackgCol, top=BackgColTop)
     p.add_text('KrakenOS',position="upper_left" ,font_size=20,color="royalblue")
     p.show_grid(font_size=6,color=GridCol)
-    p.show(auto_close=False, interactive=True, interactive_update=True)
+    p.show(auto_close=False, interactive=True, interactive_update=False)
     [cpx,cpy,cpz]=p.camera_position

--- a/KrakenOS/Examples/Examp_Axicon.py
+++ b/KrakenOS/Examples/Examp_Axicon.py
@@ -4,10 +4,13 @@
 
 import numpy as np
 
-import pkg_resources
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+try:
+    from importlib import metadata
+    installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+    missing = {pkg for pkg in required if pkg not in installed}
+except Exception:
+    missing = set()
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Axicon_And_Cylinder.py
+++ b/KrakenOS/Examples/Examp_Axicon_And_Cylinder.py
@@ -3,13 +3,13 @@
 """Examp Axicon and Cylinder"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_CzernyTurner.py
+++ b/KrakenOS/Examples/Examp_CzernyTurner.py
@@ -3,10 +3,10 @@
 """Examp Parabole Mirror Shift"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Diffraction_Grating_Reflection.py
+++ b/KrakenOS/Examples/Examp_Diffraction_Grating_Reflection.py
@@ -3,13 +3,13 @@
 """Examp Diffraction Grating Reflection"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Diffraction_Grating_Reflection_Single.py
+++ b/KrakenOS/Examples/Examp_Diffraction_Grating_Reflection_Single.py
@@ -3,13 +3,13 @@
 """Examp Diffraction Grating Reflection"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Diffraction_Grating_Transmission.py
+++ b/KrakenOS/Examples/Examp_Diffraction_Grating_Transmission.py
@@ -3,13 +3,13 @@
 """Examp Diffraction Grating Transmission"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Dispersion_By_AbbeNumber.py
+++ b/KrakenOS/Examples/Examp_Dispersion_By_AbbeNumber.py
@@ -4,14 +4,14 @@
 
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens-ParaxMatrix.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens-ParaxMatrix.py
@@ -3,10 +3,10 @@
 """Examp Doublet Lens Para xMatrix"""
 
 import time
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Doublet_Lens.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens.py
@@ -13,15 +13,15 @@ Date: 10/03/2025
 """
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 
 # =============================================================================
 # Check if KrakenOS is installed. If not, assume that the code is run from a
 # downloaded GitHub folder and add the relative path.
 # =============================================================================
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("KrakenOS is not installed. Using local GitHub folder.")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_3Dcolor.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_3Dcolor.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens 3D color"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_CommandsSystem.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_CommandsSystem.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens Commands System"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_Cylinder.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_Cylinder.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens Cylinder"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_NonSec-AR_Coating.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_NonSec-AR_Coating.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens NonSec"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_NonSec.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_NonSec.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens NonSec"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_Pupil.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_Pupil.py
@@ -19,15 +19,15 @@ Author: Joel Herrera V.
 Date: 10/03/2025
 """
 
-import pkg_resources
+from importlib import metadata
 
 # =============================================================================
 # Check if KrakenOS is installed.
 # If not, assume that the code is run from a downloaded GitHub folder and add the relative path.
 # =============================================================================
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("KrakenOS is not installed. Using local GitHub folder.")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_Pupil_Seidel.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_Pupil_Seidel.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 """Examp Doublet Lens Pupil Seidel"""
 
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_Tilt-Nulls.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_Tilt-Nulls.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens Tilt Nulls"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_Tilt.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_Tilt.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens Tilt"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_Tilt_non_sec-AR-Coating.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_Tilt_non_sec-AR-Coating.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens Tilt nonSec"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_Tilt_non_sec.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_Tilt_non_sec.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens Tilt nonSec"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Doublet_Lens_Zernike.py
+++ b/KrakenOS/Examples/Examp_Doublet_Lens_Zernike.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 """Doublet Lens Zernike"""
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Doublet_Optimization.py
+++ b/KrakenOS/Examples/Examp_Doublet_Optimization.py
@@ -5,10 +5,10 @@
 import time
 import matplotlib.pyplot as plt
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_ExtraShape_Micro_Lens_Array.py
+++ b/KrakenOS/Examples/Examp_ExtraShape_Micro_Lens_Array.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 """Examp Extra Shape Micro Lens Array"""
 
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_ExtraShape_Radial_Sine.py
+++ b/KrakenOS/Examples/Examp_ExtraShape_Radial_Sine.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 """Examp Extra Shape Radial Sine"""
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_ExtraShape_UserFacets.py
+++ b/KrakenOS/Examples/Examp_ExtraShape_UserFacets.py
@@ -14,7 +14,7 @@ Author: Joel H. V.
 Date:12/04/25
 """
 
-import pkg_resources
+from importlib import metadata
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
@@ -22,8 +22,8 @@ import matplotlib.pyplot as plt
 
 # --- Dependency check: ensure KrakenOS is installed or load from local path ---
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("KrakenOS not installed. Adding relative path.")

--- a/KrakenOS/Examples/Examp_ExtraShape_XY_Cosines.py
+++ b/KrakenOS/Examples/Examp_ExtraShape_XY_Cosines.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 """Examp Extra Shape XY Cosines"""
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_ExtraShape_XY_Cosines_UDA.py
+++ b/KrakenOS/Examples/Examp_ExtraShape_XY_Cosines_UDA.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 """Examp Extra Shape XY Cosines"""
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Flat_Mirror_45Deg.py
+++ b/KrakenOS/Examples/Examp_Flat_Mirror_45Deg.py
@@ -7,13 +7,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import sys
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Flat_NonSec_AR-caoating.py
+++ b/KrakenOS/Examples/Examp_Flat_NonSec_AR-caoating.py
@@ -3,13 +3,13 @@
 """Examp Doublet Lens NonSec"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Fresnel.py
+++ b/KrakenOS/Examples/Examp_Fresnel.py
@@ -8,7 +8,7 @@ builds an optical system in KrakenOS, and traces rays through the system to
 visualize the lens behavior.
 """
 
-import pkg_resources
+from importlib import metadata
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
@@ -19,8 +19,8 @@ from scipy.interpolate import interp1d
 # -----------------------------------------------------------------------------
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("KrakenOS is not installed. Adding relative path for local environment.")

--- a/KrakenOS/Examples/Examp_ParaboleMirror_Shift.py
+++ b/KrakenOS/Examples/Examp_ParaboleMirror_Shift.py
@@ -3,13 +3,13 @@
 """Examp Parabole Mirror Shift"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 import pickle
 
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_ParaboleMirror_Shift_UDA.py
+++ b/KrakenOS/Examples/Examp_ParaboleMirror_Shift_UDA.py
@@ -3,10 +3,10 @@
 """Examp Parabole Mirror Shift"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Perfect_lens.py
+++ b/KrakenOS/Examples/Examp_Perfect_lens.py
@@ -5,10 +5,10 @@
 import time
 import matplotlib.pyplot as plt
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Perfect_lens_Telescope.py
+++ b/KrakenOS/Examples/Examp_Perfect_lens_Telescope.py
@@ -5,10 +5,10 @@
 import time
 import matplotlib.pyplot as plt
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Pickle_Doublet_Lens_3Dcolor.py
+++ b/KrakenOS/Examples/Examp_Pickle_Doublet_Lens_3Dcolor.py
@@ -4,13 +4,13 @@
 
 import pickle
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Prism_STL-AR_coating.py
+++ b/KrakenOS/Examples/Examp_Prism_STL-AR_coating.py
@@ -3,10 +3,10 @@
 """Examp Parabole Mirror Shift"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Prism_STL.py
+++ b/KrakenOS/Examples/Examp_Prism_STL.py
@@ -3,10 +3,10 @@
 """Examp Parabole Mirror Shift"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Ray.py
+++ b/KrakenOS/Examples/Examp_Ray.py
@@ -3,10 +3,10 @@
 """Examp Ray"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Refraction_Prism.py
+++ b/KrakenOS/Examples/Examp_Refraction_Prism.py
@@ -3,13 +3,13 @@
 """Examp Diffraction Grating Transmission"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Refraction_Prism_OneRay.py
+++ b/KrakenOS/Examples/Examp_Refraction_Prism_OneRay.py
@@ -3,13 +3,13 @@
 """Examp Diffraction Grating Transmission"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Refraction_Prism_solid.py
+++ b/KrakenOS/Examples/Examp_Refraction_Prism_solid.py
@@ -3,13 +3,13 @@
 """Examp Diffraction Grating Transmission"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Refraction_Prism_solid_Generation.py
+++ b/KrakenOS/Examples/Examp_Refraction_Prism_solid_Generation.py
@@ -3,13 +3,13 @@
 """Examp Diffraction Grating Transmission"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_RonchiTest.py
+++ b/KrakenOS/Examples/Examp_RonchiTest.py
@@ -4,13 +4,13 @@ import pyvista as pv
 import scipy
 
 
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Solid_Object_STL.py
+++ b/KrakenOS/Examples/Examp_Solid_Object_STL.py
@@ -4,10 +4,10 @@
 
 # import os
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Solid_Object_STL_ARRAY.py
+++ b/KrakenOS/Examples/Examp_Solid_Object_STL_ARRAY.py
@@ -12,10 +12,10 @@ Using stl or vtk solid elements in non-sequential mode is not accurate,
 import matplotlib.pyplot as plt
 import numpy as np
 import pyvista as pv
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Source_Distribution_Function.py
+++ b/KrakenOS/Examples/Examp_Source_Distribution_Function.py
@@ -2,10 +2,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pyvista as pv
 import scipy
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Sphere 2.py
+++ b/KrakenOS/Examples/Examp_Sphere 2.py
@@ -3,10 +3,11 @@
 """Examp Parabole Mirror Shift"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
+from pathlib import Path
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")
@@ -47,8 +48,7 @@ P_Ima.Name = "Plano imagen"
 
 A = [P_Obj, M1, P_Ima]
 configuracion_1 = Kos.Setup()
-file = "/Users/joelherreravazquez/Library/CloudStorage/OneDrive-UNIVERSIDADNACIONALAUTÓNOMADEMÉXICO/Documentos/GitHub/Kraken-Optical-Simulator/KrakenOS/Cat/Gold.csv"
-# file = "/borrar/KrakenOS/Cat/Gold.csv"
+file = Path(__file__).resolve().parents[1] / "Cat" / "Gold.csv"
 configuracion_1.LoadMetal(file, "Gold", 1)
 
 # ______________________________________#
@@ -103,7 +103,6 @@ print(Rayos.RP[0], Rayos.RP[1], Rayos.RP[2])
 
 
 # x,y,z,l,m,n = Rayos.pick(-1, coordinates="local")
-
 
 
 

--- a/KrakenOS/Examples/Examp_Sphere.py
+++ b/KrakenOS/Examples/Examp_Sphere.py
@@ -3,10 +3,10 @@
 """Examp Parabole Mirror Shift"""
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Spruce-tone_Github_User (Manually enter the refractive index, dispersion and alpha).py
+++ b/KrakenOS/Examples/Examp_Spruce-tone_Github_User (Manually enter the refractive index, dispersion and alpha).py
@@ -4,14 +4,14 @@
 
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Spruce-tone_Github_User(Loading_Zemax_and_Catalogs).py
+++ b/KrakenOS/Examples/Examp_Spruce-tone_Github_User(Loading_Zemax_and_Catalogs).py
@@ -4,14 +4,14 @@
 
 
 import numpy as np
-import pkg_resources
+from importlib import metadata
 import os
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Tel_2M-STL_ImageSlicer.py
+++ b/KrakenOS/Examples/Examp_Tel_2M-STL_ImageSlicer.py
@@ -4,13 +4,13 @@
 Examp-2M-STL_ImageSlicer.py
 """
 
-import pkg_resources
+from importlib import metadata
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Tel_2M.py
+++ b/KrakenOS/Examples/Examp_Tel_2M.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 """Examp Tel 2M"""
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Tel_2M_Atmospheric_Refraction_Corrector_Adaptable.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Atmospheric_Refraction_Corrector_Adaptable.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 """Examp-Tel_2M_Atmospheric_Refraction_Corrector"""
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Tel_2M_Atmospheric_Refraction_Corrector_Static.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Atmospheric_Refraction_Corrector_Static.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 """Examp-Tel_2M_Atmospheric_Refraction_Corrector"""
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Tel_2M_Cuña.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Cuña.py
@@ -8,10 +8,10 @@ import numpy as np
 import sys
 sys.path.insert(1, '/Users/joelherreravazquez/Documents/GitHub/Kraken-Optical-Simulator/')
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Tel_2M_Echelle.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Echelle.py
@@ -6,14 +6,14 @@ import os
 import sys
 import matplotlib.pyplot as plt
 import numpy as np
-import pkg_resources
+from importlib import metadata
 
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Tel_2M_Optimization_Variables.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Optimization_Variables.py
@@ -6,10 +6,10 @@ import os
 import sys
 import matplotlib.pyplot as plt
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Tel_2M_Pupila.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Pupila.py
@@ -8,10 +8,10 @@ import numpy as np
 import sys
 sys.path.insert(1, '/Users/joelherreravazquez/Documents/GitHub/Kraken-Optical-Simulator/')
 
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Tel_2M_Spyder_Spot_Diagram.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Spyder_Spot_Diagram.py
@@ -5,10 +5,10 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pyvista as pv
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Tel_2M_Spyder_Spot_RMS.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Spyder_Spot_RMS.py
@@ -5,10 +5,10 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pyvista as pv
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/Examples/Examp_Tel_2M_Wavefront_Fitting.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Wavefront_Fitting.py
@@ -6,14 +6,14 @@ import os
 import sys
 import matplotlib.pyplot as plt
 import numpy as np
-import pkg_resources
+from importlib import metadata
 
 """ Looking for if KrakenOS is installed, if not, it assumes that
 an folder downloaded from github is run"""
 
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("Not installed")

--- a/KrakenOS/Examples/Examp_Tel_2M_Wavefront_Fitting_optimization.py
+++ b/KrakenOS/Examples/Examp_Tel_2M_Wavefront_Fitting_optimization.py
@@ -6,10 +6,10 @@ import os
 import sys
 import matplotlib.pyplot as plt
 import numpy as np
-import pkg_resources
+from importlib import metadata
 required = {'KrakenOS'}
-installed = {pkg.key for pkg in pkg_resources.working_set}
-missing = required - installed
+installed = {dist.metadata["Name"] for dist in metadata.distributions() if dist.metadata.get("Name")}
+missing = {pkg for pkg in required if pkg not in installed}
 
 if missing:
     print("No instalado")

--- a/KrakenOS/PSFMap.py
+++ b/KrakenOS/PSFMap.py
@@ -1,6 +1,3 @@
-import pkg_resources
-
-
 import KrakenOS as Kos
 
 

--- a/KrakenOS/PupilTool.py
+++ b/KrakenOS/PupilTool.py
@@ -308,6 +308,18 @@ def R_RMS(delta_Z, L, M, N, X, Y):
     R_RMS = np.sqrt(np.mean(R2))
     return R_RMS
 
+def minimize_R_RMS(delta_Z, L, M, N, X, Y):
+    """Find the axial shift that minimizes `R_RMS`.
+
+    `fsolve` tries to find a zero of `R_RMS`, but this quantity is non-negative
+    and generally does not cross zero for real systems.  Minimize the RMS value
+    directly instead to avoid spurious convergence warnings.
+    """
+    result = minimize_scalar(R_RMS, args=(L, M, N, X, Y))
+    if result.success:
+        return np.asarray([result.x])
+    return np.asarray([delta_Z])
+
 def FuncVectorCross(Z1, XYZa, LMNa, XYZb, LMNb, xy):
     """FuncVectorCross.
 
@@ -648,10 +660,10 @@ class PupilCalc():
 
         delta_Z = 0
         ZZ = (Ls, Ms, Ns, Xs, Ys)
-        v0 = scipy.optimize.fsolve(R_RMS, delta_Z, args=ZZ)
+        v0 = minimize_R_RMS(delta_Z, *ZZ)
 
         ZZ = (Le, Me, Ne, Xe, Ye)
-        vf = scipy.optimize.fsolve(R_RMS, delta_Z, args=ZZ)
+        vf = minimize_R_RMS(delta_Z, *ZZ)
 
         PosPupInp = np.asarray([0, 0, v0[0]])
         OPS = np.asarray([Le[0], Me[0], Ne[0]])
@@ -954,7 +966,6 @@ class PupilCalc():
 
         self.SYSTEM.TargSurfRest()
         return(vx, vy, vz, l, m, n)
-
 
 
 

--- a/KrakenOS/SphericalPSFCalc.py
+++ b/KrakenOS/SphericalPSFCalc.py
@@ -1,5 +1,4 @@
 import KrakenOS as Kos
-import pkg_resources
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/KrakenOS/WavefrontFit.py
+++ b/KrakenOS/WavefrontFit.py
@@ -61,7 +61,7 @@ def Zernike_Fitting(x1, y1, Z1, Arr, minimum=0.000000001):
         D = D.T
         SA = np.zeros_like(Arr)
         NA = Arr.shape[0]
-        MA = np.asarray(np.matmul(ZTZ_1_ZT, D))
+        MA = np.asarray(np.matmul(ZTZ_1_ZT, D)).reshape(-1)
 
         p = 2.5
         A=Zi
@@ -74,7 +74,7 @@ def Zernike_Fitting(x1, y1, Z1, Arr, minimum=0.000000001):
         Inv_A_T_A_A_T = np.matmul(Inv_A_T_A, A_T)
         x=np.matmul(Inv_A_T_A_A_T, b)
 
-        MA=x
+        MA = np.asarray(x).reshape(-1)
 
         cont = 0
         ZZ = []
@@ -83,7 +83,7 @@ def Zernike_Fitting(x1, y1, Z1, Arr, minimum=0.000000001):
         ZZ = np.asarray(ZZ)
         for i2 in range(0, NA):
             if (Arr[i2] != 0):
-                SA[i2] = MA[cont][0]
+                SA[i2] = MA[cont]
                 cont = (cont + 1)
             else:
                 SA[i2] = 0.0
@@ -202,4 +202,3 @@ def System_Matrix_Zernikes(x, y, A, Zern_pol, z_pow, fz):
             ZU[(cont, n)] = F
         cont = (cont + 1)
     return ZU
-

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1774763318,
+        "narHash": "sha256-fLlQQ1BGiJ8oDhTDrPW/X3jAGqKiL6CbJSvEtdDxHDk=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "177d0848dc5f1de11796e0ae3183af6d456c5246",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1774287239,
+        "narHash": "sha256-W3krsWcDwYuA3gPWsFA24YAXxOFUL6iIlT6IknAoNSE=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "fa7125ea7f1ae5430010a6e071f68375a39bd24c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773840656,
+        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,68 @@
+{ pkgs, lib, ... }:
+
+let
+  runtimeLibs = with pkgs; [
+    stdenv.cc.cc.lib
+    zlib
+    glib
+    libGL
+    fontconfig
+    freetype
+    dbus
+    wayland
+    libxkbcommon
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXtst
+    xorg.libXrender
+    xorg.libxcb
+  ];
+in
+{
+  env = {
+    GREET = "KrakenOS devenv";
+    LD_LIBRARY_PATH = lib.makeLibraryPath runtimeLibs;
+  };
+
+  languages.python = {
+    enable = true;
+    package = pkgs.python312;
+    uv.enable = true;
+  };
+
+  packages = with pkgs; [
+    git
+    pkg-config
+  ] ++ runtimeLibs;
+
+  enterShell = ''
+    VENV_DIR="$PWD/.devenv/state/venv"
+    REQ_HASH_FILE="$PWD/.devenv/state/kraken-requirements.hash"
+    REQ_HASH="krakenos-v4"
+
+    if [ ! -x "$VENV_DIR/bin/python" ]; then
+      python -m venv "$VENV_DIR"
+    fi
+
+    if [ ! -f "$REQ_HASH_FILE" ] || [ "$(cat "$REQ_HASH_FILE" 2>/dev/null)" != "$REQ_HASH" ]; then
+      "$VENV_DIR/bin/python" -m pip install --upgrade pip setuptools wheel
+      "$VENV_DIR/bin/python" -m pip install \
+        -e . \
+        numpy scipy matplotlib pandas pyvista vtk \
+        PyVTK csv342 ipython ipykernel jupyter jupyterlab pyzmq \
+        packaging setuptools basedpyright ruff PyQt5 sip
+      printf '%s\n' "$REQ_HASH" > "$REQ_HASH_FILE"
+    fi
+
+    if [ -n "''${WAYLAND_DISPLAY:-}" ] || [ -n "''${DISPLAY:-}" ]; then
+      export MPLBACKEND=qtagg
+    fi
+
+    echo "$GREET"
+    "$VENV_DIR/bin/python" --version
+  '';
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -30,7 +30,7 @@ in
 
   languages.python = {
     enable = true;
-    package = pkgs.python312;
+    package = pkgs.python313;
     uv.enable = true;
   };
 
@@ -42,10 +42,14 @@ in
   enterShell = ''
     VENV_DIR="$PWD/.devenv/state/venv"
     REQ_HASH_FILE="$PWD/.devenv/state/kraken-requirements.hash"
-    REQ_HASH="krakenos-v4"
+    REQ_HASH="krakenos-v6"
 
     if [ ! -x "$VENV_DIR/bin/python" ]; then
       python -m venv "$VENV_DIR"
+    fi
+
+    if ! "$VENV_DIR/bin/python" -m pip --version >/dev/null 2>&1; then
+      "$VENV_DIR/bin/python" -m ensurepip --upgrade
     fi
 
     if [ ! -f "$REQ_HASH_FILE" ] || [ "$(cat "$REQ_HASH_FILE" 2>/dev/null)" != "$REQ_HASH" ]; then


### PR DESCRIPTION
## Summary

  This PR updates the project for a modern Python/devenv workflow and fixes example/runtime issues that currently break on newer Python and library
  versions.

  ## Changes

  - add a `devenv` + `direnv` based development environment
  - use Python 3.13 in the project environment
  - replace `pkg_resources` usage in examples and related modules
  - fix plotting/runtime issues in:
    - `KrakenOS/Display.py`
    - `KrakenOS/PupilTool.py`
    - `KrakenOS/WavefrontFit.py`
  - fix example portability issues such as hardcoded local paths

  ## Validation

  I ran the examples under the project environment with timeouts:

  - validated with Python 3.13
  - 24 examples exited cleanly
  - 38 examples remained running as interactive windows/viewers
  - 0 examples failed with a real runtime error